### PR TITLE
refactor : 설문지 상세 조회 필터링 기능 구현 및 상태 수정 api 구현

### DIFF
--- a/Finefit/src/main/java/com/finefit/controller/OperatorController.java
+++ b/Finefit/src/main/java/com/finefit/controller/OperatorController.java
@@ -3,14 +3,17 @@ package com.finefit.controller;
 
 import com.finefit.domain.model.dto.ResultResponse;
 import com.finefit.domain.model.type.ApprovalStatusType;
+import com.finefit.domain.model.type.CounselStatusType;
 import com.finefit.service.OperatorService;
 import jakarta.servlet.http.HttpServletRequest;
+import javax.xml.transform.Result;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,10 +44,19 @@ public class OperatorController {
   }
 
   @GetMapping("/counsel")
-  public ResponseEntity<ResultResponse> getCounsel(HttpServletRequest request)
+  public ResponseEntity<ResultResponse> getCounsel(HttpServletRequest request,
+      @RequestParam(required = false) CounselStatusType counselStatus)
   {
 
-    ResultResponse response = operatorService.getCounsel(request);
+    ResultResponse response = operatorService.getCounsel(request, counselStatus);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PutMapping("/counsel")
+  public ResponseEntity<ResultResponse> updateCounselStatus(HttpServletRequest request,
+      @RequestParam Long counselId, @RequestParam CounselStatusType counselStatus) {
+
+    ResultResponse response = operatorService.updateCounselStatus(request, counselId, counselStatus);
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/Finefit/src/main/java/com/finefit/domain/entity/CounselEntity.java
+++ b/Finefit/src/main/java/com/finefit/domain/entity/CounselEntity.java
@@ -2,6 +2,8 @@ package com.finefit.domain.entity;
 
 import com.finefit.converter.ExerciseConverter;
 import com.finefit.converter.ExerciseGoalConverter;
+import com.finefit.domain.model.dto.CounselDetailDTO;
+import com.finefit.domain.model.type.CounselStatusType;
 import com.finefit.domain.model.type.DrinkingFrequencyType;
 import com.finefit.domain.model.type.ExerciseFrequencyType;
 import com.finefit.domain.model.type.ExerciseGoalType;
@@ -136,5 +138,44 @@ public class CounselEntity {
   /** 운동을 방해할 수 있는 요인 */
   private String exerciseObstacles;
 
+  @Enumerated(EnumType.STRING)
+  private CounselStatusType counselStatus;
+
   private LocalDate createAt;
+
+
+  public static CounselEntity updateCounselStatus(CounselEntity counsel, CounselStatusType counselStatus) {
+    return CounselEntity.builder()
+        .counselId(counsel.getCounselId())
+        .name(counsel.getName())
+        .contact(counsel.getContact())
+        .birthDateOrAge(counsel.getBirthDateOrAge())
+        .gender(counsel.getGender())
+        .heightAndWeight(counsel.getHeightAndWeight())
+        .targetWeightOrBody(counsel.getTargetWeightOrBody())
+        .exerciseGoal(counsel.getExerciseGoal())
+        .exerciseGoalEtc(counsel.getExerciseGoalEtc())
+        .targetPeriod(counsel.getTargetPeriod())
+        .hasPtExperience(counsel.isHasPtExperience())
+        .exerciseFrequency(counsel.getExerciseFrequency())
+        .exercise(counsel.getExercise())
+        .exerciseEtc(counsel.getExerciseEtc())
+        .preferredStyle(counsel.getPreferredStyle())
+        .mealsPerDay(counsel.getMealsPerDay())
+        .mealTimeRegularity(counsel.getMealTimeRegularity())
+        .favoriteFoods(counsel.getFavoriteFoods())
+        .dietExperience(counsel.getDietExperience())
+        .dietGoal(counsel.getDietGoal())
+        .medicalHistory(counsel.getMedicalHistory())
+        .medicationOrPrecautions(counsel.getMedicationOrPrecautions())
+        .occupationAndActivity(counsel.getOccupationAndActivity())
+        .sleepInfo(counsel.getSleepInfo())
+        .smoking(counsel.isSmoking())
+        .drinkingFrequency(counsel.getDrinkingFrequency())
+        .stressLevel(counsel.getStressLevel())
+        .exerciseObstacles(counsel.getExerciseObstacles())
+        .counselStatus(counselStatus)
+        .createAt(LocalDate.now())
+        .build();
+  }
 }

--- a/Finefit/src/main/java/com/finefit/domain/model/dto/CounselDTO.java
+++ b/Finefit/src/main/java/com/finefit/domain/model/dto/CounselDTO.java
@@ -1,6 +1,7 @@
 package com.finefit.domain.model.dto;
 
 import com.finefit.domain.entity.CounselEntity;
+import com.finefit.domain.model.type.CounselStatusType;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +18,8 @@ public class CounselDTO {
 
   private String contact;
 
+  private CounselStatusType counselStatus;
+
   private LocalDate createAt;
 
   public static List<CounselDTO> toCounselsDTO(List<CounselEntity> counsel) {
@@ -27,6 +30,7 @@ public class CounselDTO {
           .counselId(counselEntity.getCounselId())
           .name(counselEntity.getName())
           .contact(counselEntity.getContact())
+          .counselStatus(counselEntity.getCounselStatus())
           .createAt(counselEntity.getCreateAt())
           .build();
 

--- a/Finefit/src/main/java/com/finefit/domain/model/dto/CounselDetailDTO.java
+++ b/Finefit/src/main/java/com/finefit/domain/model/dto/CounselDetailDTO.java
@@ -1,6 +1,7 @@
 package com.finefit.domain.model.dto;
 
 import com.finefit.domain.entity.CounselEntity;
+import com.finefit.domain.model.type.CounselStatusType;
 import com.finefit.domain.model.type.DrinkingFrequencyType;
 import com.finefit.domain.model.type.ExerciseFrequencyType;
 import com.finefit.domain.model.type.ExerciseGoalType;
@@ -179,7 +180,6 @@ public class CounselDetailDTO {
   /** 운동을 방해할 수 있는 요인 */
   private String exerciseObstacles;
 
-
   public static CounselEntity toCounselEntity(CounselDetailDTO counselDTO) {
 
     return CounselEntity.builder()
@@ -210,6 +210,7 @@ public class CounselDetailDTO {
         .drinkingFrequency(counselDTO.getDrinkingFrequency())
         .stressLevel(counselDTO.getStressLevel())
         .exerciseObstacles(counselDTO.getExerciseObstacles())
+        .counselStatus(CounselStatusType.WAITING)
         .createAt(LocalDate.now())
         .build();
   }

--- a/Finefit/src/main/java/com/finefit/domain/model/type/CounselStatusType.java
+++ b/Finefit/src/main/java/com/finefit/domain/model/type/CounselStatusType.java
@@ -1,0 +1,16 @@
+package com.finefit.domain.model.type;
+
+import lombok.Getter;
+
+@Getter
+public enum CounselStatusType {
+
+  WAITING("대기중"),
+  COMPLETED("상담완료");
+
+  private final String description;
+
+  CounselStatusType(String description) {
+    this.description = description;
+  }
+}

--- a/Finefit/src/main/java/com/finefit/domain/model/type/SuccessResultType.java
+++ b/Finefit/src/main/java/com/finefit/domain/model/type/SuccessResultType.java
@@ -16,6 +16,7 @@ public enum SuccessResultType {
   SUCCESS_GET_COUNSEL_LIST(HttpStatus.OK, "설문지 조회 성공"),
   SUCCESS_GET_COUNSEL_DETAILS(HttpStatus.OK, "설문지 상세 조회 성공"),
   SUCCESS_REQUEST_COUNSEL(HttpStatus.OK, "설문지 작성 성공"),
+  SUCCESS_UPDATE_COUNSEL_STATUS(HttpStatus.OK, "설문지 상담 상태 수정 성공")
   ;
 
   private final HttpStatus status;

--- a/Finefit/src/main/java/com/finefit/domain/repository/CounselRepository.java
+++ b/Finefit/src/main/java/com/finefit/domain/repository/CounselRepository.java
@@ -2,6 +2,8 @@ package com.finefit.domain.repository;
 
 
 import com.finefit.domain.entity.CounselEntity;
+import com.finefit.domain.model.type.CounselStatusType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +12,7 @@ import org.springframework.stereotype.Repository;
 public interface CounselRepository extends JpaRepository<CounselEntity, Long> {
 
   Optional<CounselEntity> findByCounselId(Long counselId);
+
+  List<CounselEntity> findAllByCounselStatus(CounselStatusType counselStatus);
 
 }

--- a/Finefit/src/main/java/com/finefit/service/OperatorService.java
+++ b/Finefit/src/main/java/com/finefit/service/OperatorService.java
@@ -4,6 +4,7 @@ package com.finefit.service;
 
 import com.finefit.domain.model.dto.ResultResponse;
 import com.finefit.domain.model.type.ApprovalStatusType;
+import com.finefit.domain.model.type.CounselStatusType;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface OperatorService {
@@ -12,7 +13,9 @@ public interface OperatorService {
 
   ResultResponse updateApprovalStatus(HttpServletRequest request, Long userId, ApprovalStatusType approvalStatus);
 
-  ResultResponse getCounsel(HttpServletRequest request);
+  ResultResponse getCounsel(HttpServletRequest request, CounselStatusType counselStatus);
+
+  ResultResponse updateCounselStatus(HttpServletRequest request, Long counselId, CounselStatusType counselStatus);
 
   ResultResponse getCounselById(HttpServletRequest request, Long counselId);
 }

--- a/Finefit/src/main/java/com/finefit/service/impl/OperatorServiceImpl.java
+++ b/Finefit/src/main/java/com/finefit/service/impl/OperatorServiceImpl.java
@@ -8,6 +8,7 @@ import com.finefit.domain.model.dto.CounselDTO;
 import com.finefit.domain.model.dto.CounselDetailDTO;
 import com.finefit.domain.model.dto.ResultResponse;
 import com.finefit.domain.model.type.ApprovalStatusType;
+import com.finefit.domain.model.type.CounselStatusType;
 import com.finefit.domain.model.type.FailedResultType;
 import com.finefit.domain.model.type.RoleType;
 import com.finefit.domain.model.type.SuccessResultType;
@@ -87,12 +88,31 @@ public class OperatorServiceImpl implements OperatorService {
   }
 
   @Override
-  public ResultResponse getCounsel(HttpServletRequest request) {
+  public ResultResponse getCounsel(HttpServletRequest request, CounselStatusType counselStatus) {
 
-    List<CounselEntity> counsel = counselRepository.findAll();
+    List<CounselEntity> counsel;
+    if (counselStatus == null) {
+      counsel = counselRepository.findAll();
+    } else {
+      counsel = counselRepository.findAllByCounselStatus(counselStatus);
+    }
     List<CounselDTO> counselsList = CounselDTO.toCounselsDTO(counsel);
 
     return new ResultResponse(SuccessResultType.SUCCESS_GET_COUNSEL_LIST, counselsList);
+  }
+
+  @Override
+  public ResultResponse updateCounselStatus(HttpServletRequest request,
+      Long counselId, CounselStatusType counselStatus) {
+
+    UserEntity user = getUserByAccessToken(request);
+    isAboveOrEqual(user, RoleType.MANAGER);
+
+    CounselEntity counsel = counselRepository.findByCounselId(counselId)
+        .orElseThrow(() -> new GlobalException(FailedResultType.FAILED_COUNSEL_NOT_FOUND));
+
+    counselRepository.save(CounselEntity.updateCounselStatus(counsel, counselStatus));
+    return ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_COUNSEL_STATUS);
   }
 
   @Override


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
### OperatorController.java
* 상담 관리 API 엔드포인트 수정 및 추가
   * 상담 목록 조회(/operator/counsel) - GET 요청에 선택적 쿼리 파라미터(counselStatus) 추가하여 상태별 필터링 지원
   * 상담 상태 수정(/operator/counsel) - PUT 요청으로 특정 상담의 상태 변경 (counselId, counselStatus를 쿼리 파라미터로 전달)
   * 결과는 모두 표준화된 ResultResponse로 반환

### CounselEntity.java
* 상담 상태 관리 필드 및 메서드 추가
   * counselStatus 필드 추가 - @Enumerated(EnumType.STRING)으로 상담 상태를 문자열로 저장
   * updateCounselStatus 정적 메서드 제공 - 기존 상담의 모든 정보를 유지하면서 상태만 변경한 새로운 엔티티 반환

### CounselDTO.java
* 클라이언트에 반환할 상담 목록 정보 모델
* counselStatus 필드 추가 - 상담 상태 정보 포함
* toCounselsDTO 메서드에서 엔티티를 DTO로 변환 시 상담 상태 매핑

### CounselDetailDTO.java
* 상담 상세 정보를 위한 데이터 모델
* toCounselEntity 메서드 수정 - 새로운 상담 생성 시 기본 상태를 WAITING(대기중)으로 설정

### CounselStatusType.java (신규 생성)
* 상담 상태를 관리하는 Enum 타입 정의
   * WAITING("대기중") - 상담 대기 상태
   * COMPLETED("상담완료") - 상담 완료 상태
   * description 필드로 한글 설명 제공

### SuccessResultType.java
* 상담 관리 관련 성공 유형 추가:
   * SUCCESS_UPDATE_COUNSEL_STATUS: 설문지 상담 상태 수정 성공

### CounselRepository.java
* 상담 조회를 위한 메서드 추가:
   * findAllByCounselStatus: 특정 상담 상태의 모든 상담 목록 조회

### OperatorService.java
* 상담 관리 기능을 위한 인터페이스 정의
* getCounsel 메서드 시그니처 변경 - counselStatus 파라미터 추가
* updateCounselStatus 메서드 선언 - 상담 상태 변경 기능 추가

### OperatorServiceImpl.java
* OperatorService 인터페이스 구현
* getCounsel 로직 수정:
   * counselStatus가 null인 경우 전체 상담 목록 조회
   * counselStatus가 있는 경우 해당 상태의 상담만 필터링하여 조회
   * 조회 결과를 CounselDTO 리스트로 변환하여 반환
* updateCounselStatus 로직 구현:
   * 토큰에서 사용자 정보 추출 및 권한 검증 (MANAGER 이상)
   * 상담 ID로 상담 조회 (존재하지 않으면 예외 발생)
   * CounselEntity.updateCounselStatus로 상태 변경 후 저장
   * 성공 응답 반환

## 스크린샷

## 주의사항

Closes #24 
